### PR TITLE
fix(Settings): Update REDCAP_API_TOKEN key in settings.py


### DIFF
--- a/flourish/settings.py
+++ b/flourish/settings.py
@@ -361,7 +361,7 @@ CACHEOPS_REDIS = "redis://localhost:6379/1"
 
 REDCAP_API_URL = config['redcap_server'].get('redcap_url')
 
-REDCAP_API_TOKEN = config['redcap_server'].get('token')
+REDCAP_API_TOKEN = config['redcap_server'].get('redcap_token')
 
 
 CACHEOPS = {


### PR DESCRIPTION
The key for retrieving the REDCAP_API_TOKEN has been changed in the application settings file. This change replaces the previous 'token' key with the 'redcap_token' key to match expected syntax within the REDCAP server configuration.